### PR TITLE
Fix UBSAN in SDL_render impl

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -386,7 +386,7 @@ QueueCmdSetClipRect(SDL_Renderer *renderer)
 static int
 QueueCmdSetDrawColor(SDL_Renderer *renderer, const Uint8 r, const Uint8 g, const Uint8 b, const Uint8 a)
 {
-    const Uint32 color = ((a << 24) | (r << 16) | (g << 8) | b);
+    const Uint32 color = (((Uint32)a << 24) | (r << 16) | (g << 8) | b);
     int retval = 0;
 
     if (!renderer->color_queued || (color != renderer->last_queued_color)) {


### PR DESCRIPTION
So, zig-sdl can now be linked fine with upstream zig (provided you use BigSur), however, without this tiny patch, the binary would crash immediately at runtime. Same behaviour observed when swapped out `zig ld` for `ld64` so a miscompilation rather than mislinking.